### PR TITLE
Corrige bug ao compartilhar posts

### DIFF
--- a/MacMagazine/Classes/View Controllers/MMMPostDetailViewController.m
+++ b/MacMagazine/Classes/View Controllers/MMMPostDetailViewController.m
@@ -101,8 +101,24 @@ typedef NS_ENUM(NSUInteger, MMMLinkClickType) {
     }
 
     UIBarButtonItem *actionItem = (UIBarButtonItem *)sender;
-    NSArray<__kindof UIActivity *> *browserActivities = @[[[TUSafariActivity alloc] init], [[ARChromeActivity alloc] init]];
-    UIActivityViewController *activityViewController = [[UIActivityViewController alloc] initWithActivityItems:@[self.webView.URL] applicationActivities:browserActivities];
+    NSMutableArray *activityItems = [NSMutableArray new];
+    if (self.post) {
+        [activityItems addObject:self.post.title];
+    }
+    [activityItems addObject:self.webView.URL];
+
+    NSMutableArray<__kindof UIActivity *> *browserActivities = [NSMutableArray new];
+    [browserActivities addObject:[[TUSafariActivity alloc] init]];
+
+    NSURL *chromeURLScheme = [NSURL URLWithString:@"googlechrome-x-callback://"];
+    if ([[UIApplication sharedApplication] canOpenURL:chromeURLScheme]) {
+        ARChromeActivity *chromeActivity = [[ARChromeActivity alloc] init];
+        chromeActivity.activityTitle = NSLocalizedString(@"Post.Sharing.OpenInChrome", @"");
+        [browserActivities addObject:chromeActivity];
+    }
+
+    UIActivityViewController *activityViewController = [[UIActivityViewController alloc] initWithActivityItems:activityItems
+                                                                                         applicationActivities:browserActivities];
     activityViewController.modalPresentationStyle = UIModalPresentationPopover;
     activityViewController.popoverPresentationController.barButtonItem = actionItem;
     [self presentViewController:activityViewController animated:YES completion:nil];

--- a/MacMagazine/Supporting Files/Info.plist
+++ b/MacMagazine/Supporting Files/Info.plist
@@ -20,6 +20,10 @@
 	<string>????</string>
 	<key>CFBundleVersion</key>
 	<string>1</string>
+	<key>LSApplicationQueriesSchemes</key>
+	<array>
+		<string>googlechrome-x-callback</string>
+	</array>
 	<key>LSRequiresIPhoneOS</key>
 	<true/>
 	<key>NSAppTransportSecurity</key>

--- a/MacMagazine/Supporting Files/pt.lproj/Localizable.strings
+++ b/MacMagazine/Supporting Files/pt.lproj/Localizable.strings
@@ -10,3 +10,5 @@
 
 "Yesterday" = "ONTEM";
 
+"Post.Sharing.OpenInChrome" = "Abrir no Chrome";
+


### PR DESCRIPTION
- Chrome `UIActivity` só é visível quando o aplicativo está instalado;
- Chrome URL Scheme adicionado no `Info.plist`;
- Título do post é compartilhado quando disponível;

Fixes #3 
