### PR TITLE
Remove animação de 'fade-in' da web view

### DIFF
--- a/MacMagazine/Classes/View Controllers/MMMPostDetailViewController.m
+++ b/MacMagazine/Classes/View Controllers/MMMPostDetailViewController.m
@@ -100,8 +100,6 @@ typedef NS_ENUM(NSUInteger, MMMLinkClickType) {
     // Observer to check that loading has completelly finished for the WebView
     [self.webView addObserver:self forKeyPath:@"loading" options:NSKeyValueObservingOptionNew context:NULL];
 
-    // Hides WebView for animations
-    self.webView.hidden = YES;
     self.isLoading = YES;
 
     // Loads the request for the post URL
@@ -142,19 +140,6 @@ typedef NS_ENUM(NSUInteger, MMMLinkClickType) {
     self.navigationItem.rightBarButtonItem = rightItem;
 }
 
-- (void)removeLoadingAnimation {
-    if (!self.webView.hidden) {
-        return;
-    }
-
-    self.webView.alpha = 0.0f;
-    self.webView.hidden = NO;
-
-    [UIView animateWithDuration:0.2f delay:0.0f options:UIViewAnimationOptionCurveEaseIn animations:^{
-        self.webView.alpha = 1.0f;
-    } completion:nil];
-}
-
 - (void)performActionForLinkClickWithType:(MMMLinkClickType)linkClickType URL:(NSURL *)URL {
     if (linkClickType == MMMLinkClickTypeInternal) {
         [self pushToNewDetailViewControllerWithURL:URL];
@@ -171,9 +156,6 @@ typedef NS_ENUM(NSUInteger, MMMLinkClickType) {
     if ([keyPath isEqualToString:@"loading"] && object == self.webView) {
         // Update the right item on the navbar acordingly
         [self setupNavigationBar];
-        if (!self.webView.isLoading) {
-            [self removeLoadingAnimation];
-        }
     }
 }
 


### PR DESCRIPTION
Aparentemente com a adoção da WKWebView o hide dos elementos HTML acontece logo no inicio do load da página. 
Isso torna o fade-in de load da página desnecessário.
