### PR TITLE
Corrige login do disqus não refletir sucesso no post

### DIFF
--- a/MacMagazine/Classes/View Controllers/MMMPostDetailViewController.m
+++ b/MacMagazine/Classes/View Controllers/MMMPostDetailViewController.m
@@ -158,7 +158,7 @@ typedef NS_ENUM(NSUInteger, MMMLinkClickType) {
 #pragma mark - NSNotifications
 
 - (void)reloadWebViewsNotificationReceived:(NSNotification *)notification {
-    [self.webView reload] ;
+    [self.webView reload];
 }
 
 #pragma mark - WKNavigationDelegate Delegate


### PR DESCRIPTION
O login do disqus fica travado em uma tela com engrenagens, mesmo tendo sucesso. O app não recebe  nenhum indicativo de que deu certo. A solução foi fazer um reload da página do post quando a página de login do disqus estiver para ser dismissed e a navegação voltar ao detalhe do post.
Não é ideal, mas é o que temos pra agora.
