### PR TITLE
Forcing brazilian portuguese format on dates.

### DIFF
--- a/MacMagazine/Categories/NSDate/NSDateFormatter+Addons.m
+++ b/MacMagazine/Categories/NSDate/NSDateFormatter+Addons.m
@@ -31,7 +31,8 @@
     NSDateFormatter *formatter = [NSDateFormatter formatters][templateString];
     if (!formatter) {
         formatter = [NSDateFormatter new];
-        formatter.dateFormat = [NSDateFormatter dateFormatFromTemplate:templateString options:0 locale:[NSLocale currentLocale]];
+        formatter.locale = [NSLocale localeWithLocaleIdentifier:@"pt_BR"];
+        formatter.dateFormat = [NSDateFormatter dateFormatFromTemplate:templateString options:0 locale:formatter.locale];
         [NSDateFormatter formatters][templateString] = formatter;
     }
     return formatter;


### PR DESCRIPTION
This PR forces the "pt_BR" on the date formatter to always show dates on brazilian portuguese format.
This is related to the issue #76. 