### PR TITLE
Adding source rect to previewing context

### DIFF
--- a/MacMagazine/Classes/View Controllers/MMMPostsTableViewController.m
+++ b/MacMagazine/Classes/View Controllers/MMMPostsTableViewController.m
@@ -462,6 +462,9 @@ static NSString * const MMMReloadTableViewsNotification = @"com.macmagazine.noti
         // Used only to share post through preview action
         self.selectedPostIndexPath = indexPath;
         
+        // setting previewing context source rect
+        [previewingContext setSourceRect: [self.tableView rectForRowAtIndexPath: indexPath]];
+        
         // send data to previewViewController
         previewViewController.post = [self.fetchedResultsController objectAtIndexPath:indexPath];
         return previewViewController;


### PR DESCRIPTION
By adding source rect to previewing context the whole table view will no longer be in focus when performing peek animation, only the selected cell