### PR TITLE
Hard Coded Strings removidas

### DIFF
--- a/MacMagazine/Classes/View Controllers/MMMPostDetailViewController.m
+++ b/MacMagazine/Classes/View Controllers/MMMPostDetailViewController.m
@@ -124,14 +124,14 @@ typedef NS_ENUM(NSUInteger, MMMLinkClickType) {
 #pragma mark - Preview Actions
 
 - (NSArray<id> *)previewActionItems {
-    UIPreviewAction *sharePreviewAction = [UIPreviewAction actionWithTitle:@"Compartilhar" style:UIPreviewActionStyleDefault handler:^(UIPreviewAction * _Nonnull action, UIViewController * _Nonnull previewViewController) {
+    UIPreviewAction *sharePreviewAction = [UIPreviewAction actionWithTitle: NSLocalizedString(@"Post.Sharing.Share", @"") style:UIPreviewActionStyleDefault handler:^(UIPreviewAction * _Nonnull action, UIViewController * _Nonnull previewViewController) {
         UINotificationFeedbackGenerator *generator = [[UINotificationFeedbackGenerator alloc] init];
         [generator prepare];
         [generator notificationOccurred:(UINotificationFeedbackTypeSuccess)];
         [[NSNotificationCenter defaultCenter] postNotificationName:@"sharePost" object:nil];
     }];
 
-    UIPreviewAction *cancelPreviewAction = [UIPreviewAction actionWithTitle:@"Cancelar" style:UIPreviewActionStyleDestructive handler:^(UIPreviewAction * _Nonnull action, UIViewController * _Nonnull previewViewController) {
+    UIPreviewAction *cancelPreviewAction = [UIPreviewAction actionWithTitle: NSLocalizedString(@"Post.Sharing.Cancel", @"") style:UIPreviewActionStyleDestructive handler:^(UIPreviewAction * _Nonnull action, UIViewController * _Nonnull previewViewController) {
         UIImpactFeedbackGenerator *generator = [[UIImpactFeedbackGenerator alloc] initWithStyle:(UIImpactFeedbackStyleLight)];
         [generator prepare];
         [generator impactOccurred];

--- a/MacMagazine/Supporting Files/Info.plist
+++ b/MacMagazine/Supporting Files/Info.plist
@@ -19,7 +19,7 @@
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>
-	<string>31</string>
+	<string>32</string>
 	<key>ITSAppUsesNonExemptEncryption</key>
 	<false/>
 	<key>LSApplicationQueriesSchemes</key>

--- a/MacMagazine/Supporting Files/pt.lproj/Localizable.strings
+++ b/MacMagazine/Supporting Files/pt.lproj/Localizable.strings
@@ -6,3 +6,7 @@
 
 "Post.Sharing.OpenInChrome" = "Abrir no Chrome";
 
+"Post.Sharing.Share" = "Compartilhar";
+
+"Post.Sharing.Cancel" = "Cancelar";
+


### PR DESCRIPTION
Para continuar seguindo os padrões do App, resolvi remover as Strings Hard Coded do app e as coloquei dentro do arquivo `Localizable.strings`