### PR TITLE
[Correção] Acessibilidade de título na tela de configurações

### DIFF
--- a/MacMagazine/Base.lproj/SettingsHeaderCell.xib
+++ b/MacMagazine/Base.lproj/SettingsHeaderCell.xib
@@ -17,6 +17,9 @@
             <subviews>
                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="wordWrap" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="tXz-Go-OLY">
                     <rect key="frame" x="12" y="12" width="390" height="878"/>
+                    <accessibility key="accessibilityConfiguration">
+                        <accessibilityTraits key="traits" header="YES"/>
+                    </accessibility>
                     <fontDescription key="fontDescription" style="UICTFontTextStyleTitle2"/>
                     <color key="textColor" name="MMDarkGreyWhite"/>
                     <nil key="highlightedColor"/>

--- a/MacMagazine/Base.lproj/SettingsSubHeaderCell.xib
+++ b/MacMagazine/Base.lproj/SettingsSubHeaderCell.xib
@@ -17,6 +17,9 @@
             <subviews>
                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="wordWrap" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="tXz-Go-OLY">
                     <rect key="frame" x="12" y="12" width="390" height="858"/>
+                    <accessibility key="accessibilityConfiguration">
+                        <accessibilityTraits key="traits" header="YES"/>
+                    </accessibility>
                     <fontDescription key="fontDescription" style="UICTFontTextStyleTitle2"/>
                     <color key="textColor" name="MMDarkGreyWhite"/>
                     <nil key="highlightedColor"/>


### PR DESCRIPTION
![Simulator Screen Shot - iPhone 12 Pro Max - 2021-04-17 at 17](https://user-images.githubusercontent.com/6379664/115125988-3ce39c00-9fa2-11eb-8336-d0127d90f394.jpg)

Na tela de configurações as configurações, os títulos não estavam sendo anunciados como título.
