### PR TITLE
Correção #221 Navegar de volta para Posts no detalhe de um Post

### DIFF
--- a/MacMagazine/TabBarController.swift
+++ b/MacMagazine/TabBarController.swift
@@ -66,18 +66,9 @@ class TabBarController: NSObject, UITabBarControllerDelegate {
                   let navVC = splitVC.children[0] as? UINavigationController,
                   let viewController = navVC.children[0] as? PostsMasterViewController {
             if previousController == viewController || previousController == nil {
-                if navVC.children.count > 1,
-                   let navDetail = navVC.children[1] as? UINavigationController,
-                   let detail = navDetail.children[0] as? PostsDetailViewController,
-                   navVC.visibleViewController == detail {
-                    navVC.popViewController(animated: true)
-                } else {
-                    if viewController.tableView.numberOfSections > 0 &&
-                        viewController.tableView.numberOfRows(inSection: 0) > 0 {
-                        viewController.tableView.selectRow(at: IndexPath(row: 0, section: 0), animated: true, scrollPosition: .bottom)
-                        viewController.tableView.deselectRow(at: IndexPath(row: 0, section: 0), animated: false)
-                    }
-                }
+                viewController.tableView.selectRow(at: IndexPath(row: 0, section: 0), animated: true, scrollPosition: .bottom)
+                viewController.tableView.deselectRow(at: IndexPath(row: 0, section: 0), animated: false)
+                navVC.popViewController(animated: true)
             }
             previousController = viewController
         } else if let navVC = viewController as? UINavigationController,


### PR DESCRIPTION
Esta alteração corrige o comportamento descrito em #221.

Identifiquei que as validações extras não estavam sendo utilizadas, e o método `.popViewController()` é o responsável por levar o usuário de volta à lista de posts. Porém, este não era executado quando a condição que verifica se a view atual é um `PostDetailViewController` não era atendida. Por estes motivos, removi a condição e adicionei o método logo após as interações com o `tableView`.

Fiz os testes em meu ambiente, e consigo navegar de volta tanto abrindo um post pela lista, ou abrindo pelas notificações ou widgets. Gravei este vídeo mostrando o comportamento: https://vimeo.com/934975652