### PR TITLE
Correção de margens nos widgets

### DIFF
--- a/MacMagazineWidgetExtension/MacMagazineWidgetExtension.swift
+++ b/MacMagazineWidgetExtension/MacMagazineWidgetExtension.swift
@@ -39,6 +39,17 @@ struct MacMagazineWidgetExtension: Widget {
         .configurationDisplayName("MacMagazine")
         .description("Confira nossos últimos posts!")
         .supportedFamilies(supportedFamilies)
+        .disableMargins()
+    }
+}
+
+private extension WidgetConfiguration {
+    func disableMargins() -> some WidgetConfiguration {
+        if #available(iOSApplicationExtension 15.0, *) {
+            return contentMarginsDisabled()
+        } else {
+            return self
+        }
     }
 }
 


### PR DESCRIPTION
Margens dos widgets estão excessivas após a lançamento do iOS 17. Aplicando o modifier `contentMarginsDisabled` resolve o problema.

### Antes

![Simulator Screenshot - iPhone SE (3rd generation) - 2024-05-18 at 09 00 24](https://github.com/MacMagazine/app-iOS/assets/24867592/627fdfb3-e94b-4370-8508-6a49741c4e85)


### Depois

![Simulator Screenshot - iPhone SE (3rd generation) - 2024-05-18 at 09 00 43](https://github.com/MacMagazine/app-iOS/assets/24867592/637b5da2-5385-4586-b0ce-24e188754662)

