### PR TITLE
[FEATURE] - Add search posts option in app shortcuts (#234)

### DIFF
--- a/MacMagazine.xcodeproj/project.pbxproj
+++ b/MacMagazine.xcodeproj/project.pbxproj
@@ -3,7 +3,7 @@
 	archiveVersion = 1;
 	classes = {
 	};
-	objectVersion = 56;
+	objectVersion = 70;
 	objects = {
 
 /* Begin PBXBuildFile section */
@@ -382,6 +382,10 @@
 		9BFD100528DF5F3B002B36A6 /* Helper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Helper.swift; sourceTree = "<group>"; };
 		9BFD100928DF5F8F002B36A6 /* CoreDataStackExtension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CoreDataStackExtension.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
+
+/* Begin PBXFileSystemSynchronizedRootGroup section */
+		0F9AA4892E3C0B870099EB48 /* Enums */ = {isa = PBXFileSystemSynchronizedRootGroup; explicitFileTypes = {}; explicitFolders = (); path = Enums; sourceTree = "<group>"; };
+/* End PBXFileSystemSynchronizedRootGroup section */
 
 /* Begin PBXFrameworksBuildPhase section */
 		5EB2017B25B3664C00E17642 /* Frameworks */ = {
@@ -778,6 +782,7 @@
 		9BE697DA1F487DAB0048D68D /* Comum */ = {
 			isa = PBXGroup;
 			children = (
+				0F9AA4892E3C0B870099EB48 /* Enums */,
 				9B0DD4482226B9600016C567 /* API */,
 				9BC9B12F1F5C96A500C4DF17 /* Cells */,
 				9B3C7A5522638012001146A4 /* Controllers */,
@@ -918,6 +923,9 @@
 				9B9C7F9F226BF836000534CA /* PBXTargetDependency */,
 				9BB4BC68225B99F700559170 /* PBXTargetDependency */,
 				5EB2018D25B3665100E17642 /* PBXTargetDependency */,
+			);
+			fileSystemSynchronizedGroups = (
+				0F9AA4892E3C0B870099EB48 /* Enums */,
 			);
 			name = MacMagazine;
 			packageProductDependencies = (

--- a/MacMagazine/AppDelegateExtensions.swift
+++ b/MacMagazine/AppDelegateExtensions.swift
@@ -16,6 +16,7 @@ import UIKit
 extension Notification.Name {
 	static let shortcutActionLastPost = Notification.Name("shortcutActionLastPost")
 	static let shortcutActionRecentPost = Notification.Name("shortcutActionRecentPost")
+    static let shortcutActionSearchPost = Notification.Name("shortcutActionSearchPost")
 	static let reloadWeb = Notification.Name("reloadWeb")
 	static let scrollToTop = Notification.Name("scrollToTop")
 	static let favoriteUpdated = Notification.Name("favoriteUpdated")
@@ -124,14 +125,19 @@ extension AppDelegate {
 extension AppDelegate {
     func application(_ application: UIApplication, performActionFor shortcutItem: UIApplicationShortcutItem, completionHandler: @escaping (Bool) -> Void) {
         if shortcutItem.type == "openLastSeenPost" ||
-            shortcutItem.type == "openMostRecentPost" {
+            shortcutItem.type == "openMostRecentPost" ||
+            shortcutItem.type == "openSearchPost" {
+
+            let shortcutItem = ShortcutActions(rawValue: shortcutItem.type) ?? .none
 
             guard let tabController = (UIApplication.shared.connectedScenes.first as? UIWindowScene)?.windows.last?.rootViewController as? UITabBarController else {
-                shortcutAction = shortcutItem.type == "openLastSeenPost" ? .shortcutActionLastPost : .shortcutActionRecentPost
+                shortcutAction = shortcutItem.notificationName
                 return
             }
             tabController.selectedIndex = 0
-            NotificationCenter.default.post(name: shortcutItem.type == "openLastSeenPost" ? .shortcutActionLastPost : .shortcutActionRecentPost, object: nil)
+
+            guard let notificationName = shortcutItem.notificationName else { return }
+            NotificationCenter.default.post(name: notificationName, object: nil)
         }
     }
 }
@@ -141,7 +147,7 @@ extension AppDelegate {
 extension AppDelegate {
 	func application(_ application: UIApplication, continue userActivity: NSUserActivity, restorationHandler: @escaping ([UIUserActivityRestoring]?) -> Void) -> Bool {
 		if userActivity.activityType == CSSearchableItemActionType {
-			if let identifier = userActivity.userInfo? [CSSearchableItemActivityIdentifier] as? String {
+			if let identifier = userActivity.userInfo?[CSSearchableItemActivityIdentifier] as? String {
                 guard (UIApplication.shared.connectedScenes.first as? UIWindowScene)?.windows.last?.rootViewController as? UITabBarController != nil else {
                     widgetSpotlightPost = identifier
                     return true

--- a/MacMagazine/Enums/ShortcutActions.swift
+++ b/MacMagazine/Enums/ShortcutActions.swift
@@ -1,0 +1,25 @@
+//
+//  ShortcutActions.swift
+//  MacMagazine
+//
+//  Created by Marcos Ferreira on 31/07/25.
+//  Copyright © 2025 MacMagazine. All rights reserved.
+//
+
+import Foundation
+
+enum ShortcutActions: String {
+    case openLastSeenPost
+    case openMostRecentPost
+    case openSearchPost
+    case none = ""
+
+    var notificationName: Notification.Name? {
+        switch self {
+        case .openLastSeenPost: return .shortcutActionLastPost
+        case .openMostRecentPost: return .shortcutActionRecentPost
+        case .openSearchPost: return .shortcutActionSearchPost
+        case .none: return nil
+        }
+    }
+}

--- a/MacMagazine/Info.plist
+++ b/MacMagazine/Info.plist
@@ -74,6 +74,14 @@
 			<key>UIApplicationShortcutItemType</key>
 			<string>openMostRecentPost</string>
 		</dict>
+        <dict>
+            <key>UIApplicationShortcutItemIconSymbolName</key>
+            <string>magnifyingglass</string>
+            <key>UIApplicationShortcutItemTitle</key>
+            <string>Buscar nos posts</string>
+            <key>UIApplicationShortcutItemType</key>
+            <string>openSearchPost</string>
+        </dict>
 	</array>
 	<key>UIBackgroundModes</key>
 	<array>

--- a/MacMagazine/PostsMasterViewController.swift
+++ b/MacMagazine/PostsMasterViewController.swift
@@ -119,6 +119,7 @@ class PostsMasterViewController: UITableViewController, FetchedResultsController
 
         NotificationCenter.default.addObserver(self, selector: #selector(onShortcutActionLastPost(_:)), name: .shortcutActionLastPost, object: nil)
 		NotificationCenter.default.addObserver(self, selector: #selector(onShortcutActionRecentPost(_:)), name: .shortcutActionRecentPost, object: nil)
+        NotificationCenter.default.addObserver(self, selector: #selector(onShortcutActionSearchPost(_:)), name: .shortcutActionSearchPost, object: nil)
 
 		if Settings().isPad {
 			NotificationCenter.default.addObserver(self, selector: #selector(onUpdateSelectedPost(_:)), name: .updateSelectedPost, object: nil)
@@ -637,6 +638,12 @@ extension PostsMasterViewController {
 		processOption()
 	}
 
+    @objc func onShortcutActionSearchPost(_ notification: Notification) {
+        delay(0.01) { [weak self] in
+            self?.openSearch()
+        }
+    }
+
 }
 
 // MARK: - Common Methods -
@@ -860,6 +867,10 @@ extension PostsMasterViewController {
 
 extension PostsMasterViewController {
     @IBAction private func search(_ sender: Any) {
+        openSearch()
+    }
+
+    fileprivate func openSearch() {
         navigationItem.searchController = searchController
         navigationItem.hidesSearchBarWhenScrolling = false
         resultsTableController?.showTyping()


### PR DESCRIPTION
Implementação do novo atalho no ícone do app, com a opção de "Buscar nos posts" conforme issue #234 

Abaixo a lista das changes que foram aplicadas:

- Adicionada nova opção de `shortcutItem` com o texto `Buscar nos posts` e o ícone de search
- Foi realizada uma pequena refatoração na classe `PostMasterViewController` de forma a permitir a chamada ao gatilho que abre a pesquisa, sem a necessidade de duplicação de código, para isso, o trecho responsável por abrir a pesquisa foi extraído para uma função `fileprivate` a fim de conservar a legibilidade e manutenabilidade do código.
- Como a forma de determinar qual a ação seria executada após o click em um dos atalhos do ícone estava sendo feita com um operador ternário, pois só havia 2 opções, resolvi extrair esses elementos para um enumerando, permitindo dessa forma que, se necessário/desejado, sejam adicionadas novas funcionalidades no futuro. Dito isto, foi criado um novo `group` com o nome de `Enums` onde foi criado um novo enumerando `ShortcutActions`, esse enumerando possui uma variável computada que devolve o nome da notificação que deve ser disparada de acordo com cada ação. Assim, ao interceptarmos o evento no `AppDelegate` de clique em um dos atalhos, o código converte esse elemento em um dos ítens do enum, e dispara o evento respectivo para cada operação.
- Devido a essa abordagem, gerou-se uma change no `project.pbxproj` a fim de mapear essa nova adição.
- Aproveitei também a oportunidade e corrigi uma violação de `space` do `lint` na linha `userActivity.userInfo? [CSSearchableItemActivityIdentifier] as? String`
- Foi adicionado também na `PostMasterViewController` a "escuta" da nova notificação para disparar a trigger para abrir a tela de pesquisa.
- A título de informação foi criado o case de `none` no enumerando de actions, dessa forma, caso a tentativa de criar a opção de atalho falhe (por qualquer motivo), o `.none` é assumido para garantir que não haja nenhum tipo de comportamento inesperado pelo app.

**Evidências:**

*Novo atalho ao clicar e segurar no ícone do app*

<img width="1206" height="2622" alt="Simulator Screenshot - iPhone 16 Pro - 2025-07-31 at 17 22 33" src="https://github.com/user-attachments/assets/4622fe40-932c-4a61-b904-9ced87b3d325" />

*Demonstração da funcionalidade*

https://github.com/user-attachments/assets/0da327bb-8299-4ffe-af83-b84471714a22

