### PR TITLE
Fixes Soundclound CTA blocking webview interaction

### DIFF
--- a/MacMagazine/Webview/SoundcloudPlayer.swift
+++ b/MacMagazine/Webview/SoundcloudPlayer.swift
@@ -48,6 +48,8 @@ class SoundcloudPlayer: WKWebView {
 			}
 			iFrame = iFrame?.replacingOccurrences(of: "show_artwork=false", with: "show_artwork=false&download=false&sharing=false")
 
+            iFrame = iFrame?.replacingOccurrences(of: "show_teaser=true", with: "show_teaser=false")
+
 			DispatchQueue.main.async {
 				self.navigationDelegate = self
 				self.loadHTMLString(self.embedVideoHtml, baseURL: nil)


### PR DESCRIPTION
Fixes the SoundCloud player user interaction that was being blocked because of the CTA to listen in their App.

PS: I tried to add the replacement in the line 49 along with the others, but some podcasts are coming with this value as true, and that wouldn't override the previous value

| Before | After |
|--------|--------|
| <img width="1170" height="2532" alt="image" src="https://github.com/user-attachments/assets/8ae48d05-2dbb-46d6-bc5b-7bdaa614e6a0" /> | <img width="1170" height="2532" alt="image" src="https://github.com/user-attachments/assets/f0c4f526-1194-44bd-98b2-7a10e9672ce2" /> | 