### PR TITLE
fix(#277): specify CloudKit container for iCloud sync

### DIFF
--- a/MacMagazine/MacMagazine/MainApp/MainViewModel.swift
+++ b/MacMagazine/MacMagazine/MainApp/MainViewModel.swift
@@ -64,6 +64,7 @@ class MainViewModel {
 
         self.storage = Database(
             models: models,
+            cloudKitDatabase: .private("iCloud.com.brit.macmagazine.cloudkit"),
             inMemory: inMemory
         )
 


### PR DESCRIPTION
## Summary

- Favorites were not syncing between devices because SwiftData's `.automatic` CloudKit mode looks for the default container (`iCloud.com.brit.macmagazine`), but the app's entitlements declare `iCloud.com.brit.macmagazine.cloudkit`
- Fixed by explicitly passing `.private("iCloud.com.brit.macmagazine.cloudkit")` to the `Database` initializer so SwiftData uses the correct CloudKit container

Closes #277

## Test plan

- [ ] Sign into iCloud on two devices (iPhone + Mac or iPhone + iPad)
- [ ] Favorite an article on device A
- [ ] Verify the favorite appears on device B after a short sync delay
- [ ] Unfavorite on device B, verify it unfavorites on device A
- [ ] Fresh install: verify existing favorites sync down from iCloud

🤖 Generated with [Claude Code](https://claude.com/claude-code)