### PR TITLE
fix(#280): increase cookie expiration from 60s to 24h

### DIFF
--- a/MacMagazine/Features/MacMagazineUILibrary/Sources/MacMagazineUILibrary/Webview/Cookies.swift
+++ b/MacMagazine/Features/MacMagazineUILibrary/Sources/MacMagazineUILibrary/Webview/Cookies.swift
@@ -5,6 +5,7 @@ public struct Cookies {
 
     static let disqus = "disqus.com"
     static let mmDomain = "macmagazine.com.br"
+    private static let cookieExpiration: TimeInterval = 86_400
 
     private static let disqusCookiesKey = "disqus_saved_cookies"
 
@@ -52,7 +53,7 @@ public struct Cookies {
             .name: "_color_schema",
             .value: value,
             .secure: "true",
-            .expires: NSDate(timeIntervalSinceNow: 60)
+            .expires: NSDate(timeIntervalSinceNow: cookieExpiration)
         ])
     }
 
@@ -63,7 +64,7 @@ public struct Cookies {
             .name: "darkmode",
             .value: value,
             .secure: "true",
-            .expires: NSDate(timeIntervalSinceNow: 60)
+            .expires: NSDate(timeIntervalSinceNow: cookieExpiration)
         ])
     }
 
@@ -74,7 +75,7 @@ public struct Cookies {
             .name: "fonte",
             .value: value,
             .secure: "true",
-            .expires: NSDate(timeIntervalSinceNow: 60)
+            .expires: NSDate(timeIntervalSinceNow: cookieExpiration)
         ])
     }
 
@@ -85,7 +86,7 @@ public struct Cookies {
             .name: "version",
             .value: value,
             .secure: "true",
-            .expires: NSDate(timeIntervalSinceNow: 60)
+            .expires: NSDate(timeIntervalSinceNow: cookieExpiration)
         ])
     }
 
@@ -96,7 +97,7 @@ public struct Cookies {
             .name: "patr",
             .value: value,
             .secure: "true",
-            .expires: NSDate(timeIntervalSinceNow: 60)
+            .expires: NSDate(timeIntervalSinceNow: cookieExpiration)
         ])
     }
 }


### PR DESCRIPTION
## Summary

- Ad banners were reappearing despite valid subscriptions because the `patr` cookie expired after just 60 seconds
- In v4 (UIKit), this worked because `HTTPCookieStorage.shared` kept cookies alive process-wide. In v5 (SwiftUI native WebView), cookies are scoped to `WKWebsiteDataStore` and truly expire after the set interval
- Deferred/lazy-loaded ads that fire after 60s no longer saw the `patr` cookie, causing banners to reappear
- Increased expiration to 24 hours (86,400s) — cookies are still re-created fresh on every page load, so there's no stale-data risk
- Extracted the expiration value into a `cookieExpiration` constant for maintainability

Closes #280

## Test plan

- [ ] Open an article as a subscriber — verify no ads appear
- [ ] Stay on the article for >60 seconds — verify ads don't reappear
- [ ] Scroll through the article (trigger lazy-loaded content) — verify no ads
- [ ] Open multiple articles in sequence — verify no ads on any
- [ ] Test without subscription — verify ads DO appear (cookie value is "false")
- [ ] Run `MacMagazineUILibraryTests` — all cookie tests pass ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)