### PR TITLE
fix(#274): improve toolbar button responsiveness in article views

### DIFF
--- a/MacMagazine/Features/MacMagazineUILibrary/Sources/MacMagazineUILibrary/Webview/ManagedWebView.swift
+++ b/MacMagazine/Features/MacMagazineUILibrary/Sources/MacMagazineUILibrary/Webview/ManagedWebView.swift
@@ -94,7 +94,8 @@ private extension ManagedWebView {
     @ViewBuilder
     var webview: some View {
         if let page, isActive {
-            Color.clear.opacity(0)
+            Color.clear
+                .allowsHitTesting(false)
                 .safeAreaInset(edge: .trailing, spacing: shouldUseSidebar ? nil : 0) {
                     WebView(page)
                         .webViewBackForwardNavigationGestures(


### PR DESCRIPTION
## Summary

- Navigation bar buttons (back, share, favorite, filters) required multiple taps to respond
- **Root cause:** `Color.clear.opacity(0)` in `ManagedWebView` was intercepting touches. This invisible view serves as a layout container for iPad sidebar spacing (`.safeAreaInset(edge: .trailing)`), but SwiftUI's hit-testing considers view frame regardless of opacity
- **Fix:** Replaced `.opacity(0)` with `.allowsHitTesting(false)` — preserves the layout behavior for iPad while ensuring touches pass through to the toolbar button layer

Closes #274

## Test plan

- [ ] Open an article — tap back button: should respond on first tap
- [ ] Tap share button in article: should respond on first tap
- [ ] Tap favorite button in article: should respond on first tap
- [ ] Open news filter: button should respond on first tap
- [ ] iPad: verify article content still respects sidebar spacing
- [ ] Verify WebView content itself remains scrollable and interactive

🤖 Generated with [Claude Code](https://claude.com/claude-code)