### PR TITLE
fix(#272): improve podcast full player accessibility

### DIFF
--- a/MacMagazine/Features/PodcastLibrary/Sources/Podcast/Modifiers/CardAccessibilityModifier.swift
+++ b/MacMagazine/Features/PodcastLibrary/Sources/Podcast/Modifiers/CardAccessibilityModifier.swift
@@ -19,7 +19,7 @@ private extension Array where Element == CardLabel {
             case .duration: text.append("com duração de \(data.type.duration.accessibilityTime)")
             }
         }
-        return "Podcast " + text.joined(separator: ", ") + "."
+        return text.joined(separator: ", ") + "."
     }
 }
 

--- a/MacMagazine/Features/PodcastLibrary/Sources/Podcast/Views/Player/FullPlayerView.swift
+++ b/MacMagazine/Features/PodcastLibrary/Sources/Podcast/Views/Player/FullPlayerView.swift
@@ -22,18 +22,18 @@ enum PodcastBackgroundGradientStyle {
 // MARK: - Accessibility Sort Priority -
 
 enum PlayerAccessibilityPriority {
-    static let favoriteButton: Double = 12
-    static let shareButton: Double = 11
-    static let podcastTitle: Double = 10
-    static let previousChapter: Double = 9
+    static let podcastTitle: Double = 12
+    static let playPauseButton: Double = 11
+    static let skipBackwardButton: Double = 10
+    static let skipForwardButton: Double = 9
     static let progressSlider: Double = 8
-    static let nextChapter: Double = 7
-    static let volumeSlider: Double = 6
+    static let previousChapter: Double = 7
+    static let nextChapter: Double = 6
     static let speedButton: Double = 5
-    static let skipBackwardButton: Double = 4
-    static let playPauseButton: Double = 3
-    static let skipForwardButton: Double = 2
-    static let chaptersButton: Double = 1
+    static let volumeSlider: Double = 4
+    static let chaptersButton: Double = 3
+    static let favoriteButton: Double = 2
+    static let shareButton: Double = 1
 }
 
 // MARK: - PodcastPlayerView -
@@ -230,6 +230,8 @@ private extension FullPlayerView {
         Ticker(text: title, speed: 30)
             .bold()
             .frame(height: 40)
+            .accessibilityLabel(title)
+            .accessibilityAddTraits(.isHeader)
             .accessibilitySortPriority(PlayerAccessibilityPriority.podcastTitle)
     }
 
@@ -247,6 +249,7 @@ private extension FullPlayerView {
             HStack(spacing: 40) {
                 skipButton(
                     systemName: "gobackward.15",
+                    label: "Voltar 15 segundos",
                     action: {
                         playerManager.skip(by: -15)
                         analytics.track(.buttonTap(
@@ -262,6 +265,7 @@ private extension FullPlayerView {
 
                 skipButton(
                     systemName: "goforward.15",
+                    label: "Avançar 15 segundos",
                     action: {
                         playerManager.skip(by: 15)
                         analytics.track(.buttonTap(
@@ -311,6 +315,7 @@ private extension FullPlayerView {
                     Image(systemName: "backward.end")
                 })
                 .font(.system(size: 20))
+                .accessibilityLabel("Capítulo anterior")
                 .accessibilitySortPriority(PlayerAccessibilityPriority.previousChapter)
 
                 Slider(
@@ -333,6 +338,8 @@ private extension FullPlayerView {
                 )
                 .sliderThumbVisibility(.hidden)
                 .tint(.primary)
+                .accessibilityLabel("Posição da reprodução")
+                .accessibilityValue("\(formatTime(displayTime)) de \(formatTime(safeDuration))")
                 .accessibilitySortPriority(PlayerAccessibilityPriority.progressSlider)
 
                 Button(action: {
@@ -346,6 +353,7 @@ private extension FullPlayerView {
                     Image(systemName: "forward.end")
                 })
                 .font(.system(size: 20))
+                .accessibilityLabel("Próximo capítulo")
                 .accessibilitySortPriority(PlayerAccessibilityPriority.nextChapter)
             }
 
@@ -371,9 +379,10 @@ private extension FullPlayerView {
                 .accessibilityHidden(true)
 
             SystemVolumeView()
-            .tint(.primary)
-            .frame(height: 18)
-            .accessibilitySortPriority(PlayerAccessibilityPriority.volumeSlider)
+                .tint(.primary)
+                .frame(height: 18)
+                .accessibilityLabel("Volume")
+                .accessibilitySortPriority(PlayerAccessibilityPriority.volumeSlider)
 
             Image(systemName: "speaker.wave.3")
                 .foregroundColor(.secondary)
@@ -395,14 +404,16 @@ private extension FullPlayerView {
             Image(systemName: playerManager.isPlaying ? "pause.fill" : "play.fill")
         }
         .font(.system(size: 52))
+        .accessibilityLabel(playerManager.isPlaying ? "Pausar" : "Reproduzir")
     }
 
     @ViewBuilder
-    func skipButton(systemName: String, action: @escaping () -> Void) -> some View {
+    func skipButton(systemName: String, label: String, action: @escaping () -> Void) -> some View {
         Button(action: action) {
             Image(systemName: systemName)
         }
         .font(.system(size: 28))
+        .accessibilityLabel(label)
     }
 }
 
@@ -461,15 +472,15 @@ private extension FullPlayerView {
                 )
         }
         .accessibilityLabel("Velocidade de reprodução")
-        .accessibilityValue("\(currentSpeed)")
+        .accessibilityValue(accessibleSpeedValue(currentSpeed))
         .accessibilityAddTraits(.allowsDirectInteraction)
         .accessibilityAdjustableAction { direction in
             let currentSpeed = Double(playerManager.playbackRate)
             switch direction {
             case .increment:
-                playerManager.setPlaybackRate(Float(currentSpeed + 0.5))
+                playerManager.setPlaybackRate(Float(min(currentSpeed + 0.25, 3.0)))
             case .decrement:
-                playerManager.setPlaybackRate(Float(currentSpeed - 0.5))
+                playerManager.setPlaybackRate(Float(max(currentSpeed - 0.25, 0.5)))
             @unknown default:
                 break
             }
@@ -609,6 +620,18 @@ private extension FullPlayerView {
         } else {
             return String(format: "%d:%02d", minutes, seconds)
         }
+    }
+
+    func accessibleSpeedValue(_ speed: Double) -> String {
+        if abs(speed - 1.0) < 0.001 {
+            return "normal"
+        }
+        let formatter = NumberFormatter()
+        formatter.locale = Locale(identifier: "pt-BR")
+        formatter.minimumFractionDigits = speed.truncatingRemainder(dividingBy: 1) == 0.0 ? 0 : 1
+        formatter.maximumFractionDigits = 2
+        let base = formatter.string(from: NSNumber(value: speed)) ?? String(speed)
+        return "\(base) vezes"
     }
 
     func formattedSpeedForButton(_ value: Double, isSelected: Bool) -> String {


### PR DESCRIPTION
## Summary

### Full Player VoiceOver improvements:
- **Reading order** — Title reads first, then play/pause, skip controls, progress, speed, volume, chapters, and finally favorite/share actions
- **Labels** — All buttons now have Portuguese accessibility labels (Reproduzir, Pausar, Voltar 15 segundos, Avançar 15 segundos, Capítulo anterior, Próximo capítulo)
- **Progress slider** — Now announces "Posição da reprodução" with value "X de Y" format
- **Speed button** — Value reads "normal" at 1x, "1,5 vezes" at 1.5x, etc. Adjustable in 0.25 steps (was 0.5), bounded 0.5–3.0
- **Title** — Marked as `.isHeader` trait for VoiceOver rotor navigation
- **Volume** — Labeled "Volume" for clarity

### Podcast card accessibility:
- Removed redundant "Podcast" prefix from card accessibility text (the section context already conveys this)

Closes #272

## Test plan

- [ ] Enable VoiceOver on device
- [ ] Open podcast full player — verify title is announced first
- [ ] Swipe through elements — verify logical order: title → play/pause → skip back → skip forward → slider → prev chapter → next chapter → speed → volume → chapters → favorite → share
- [ ] On speed button: swipe up/down to adjust — verify "normal", "1,25 vezes", "1,5 vezes" announcements
- [ ] On progress slider: verify it announces "Posição da reprodução, X de Y"
- [ ] Navigate to podcast list — verify cards no longer prefix with "Podcast"
- [ ] All tests pass ✅ (55 podcast tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)