### PR TITLE
fix(podcast): correct accessibility sort order in full player

### DIFF
--- a/MacMagazine/Features/PodcastLibrary/Sources/Podcast/Views/Player/FullPlayerView.swift
+++ b/MacMagazine/Features/PodcastLibrary/Sources/Podcast/Views/Player/FullPlayerView.swift
@@ -22,18 +22,18 @@ enum PodcastBackgroundGradientStyle {
 // MARK: - Accessibility Sort Priority -
 
 enum PlayerAccessibilityPriority {
-    static let podcastTitle: Double = 12
-    static let playPauseButton: Double = 11
-    static let skipBackwardButton: Double = 10
-    static let skipForwardButton: Double = 9
+    static let favoriteButton: Double = 12
+    static let shareButton: Double = 11
+    static let podcastTitle: Double = 10
+    static let previousChapter: Double = 9
     static let progressSlider: Double = 8
-    static let previousChapter: Double = 7
-    static let nextChapter: Double = 6
-    static let speedButton: Double = 5
-    static let volumeSlider: Double = 4
-    static let chaptersButton: Double = 3
-    static let favoriteButton: Double = 2
-    static let shareButton: Double = 1
+    static let nextChapter: Double = 7
+    static let speedButton: Double = 6
+    static let skipBackwardButton: Double = 5
+    static let playPauseButton: Double = 4
+    static let skipForwardButton: Double = 3
+    static let chaptersButton: Double = 2
+    static let volumeSlider: Double = 1
 }
 
 // MARK: - PodcastPlayerView -


### PR DESCRIPTION
## Summary
- Reorders `PlayerAccessibilityPriority` values to match the visual layout (top-to-bottom, left-to-right)
- VoiceOver now traverses: favorite → share → title → previous chapter → progress → next chapter → speed → skip back → play/pause → skip forward → chapters → volume

## Test plan
- [ ] Enable VoiceOver on the podcast full player
- [ ] Swipe right through all elements and verify order matches visual layout
- [ ] Test in both portrait and landscape orientations

🤖 Generated with [Claude Code](https://claude.com/claude-code)