### PR TITLE
fix(settings): fix InApp purchase not updating removeAds environment

### DIFF
--- a/MacMagazine/Features/SettingsLibrary/Sources/SettingsLibrary/ViewModels/SubscriptionViewModel.swift
+++ b/MacMagazine/Features/SettingsLibrary/Sources/SettingsLibrary/ViewModels/SubscriptionViewModel.swift
@@ -39,18 +39,17 @@ final class SubscriptionViewModel {
 
     func setupListeners() {
         observationTask = Task { @MainActor [weak self] in
-            guard let self else { return }
             while !Task.isCancelled {
-                let currentStatus = withObservationTracking {
-                    self.inAppLibrary.status
-                } onChange: {
-                    // This closure is called when status changes
+                guard let self else { return }
+                await withCheckedContinuation { continuation in
+                    withObservationTracking {
+                        _ = self.inAppLibrary.status
+                    } onChange: {
+                        continuation.resume()
+                    }
                 }
-
-                self.process(purchased: currentStatus)
-
-                // Small delay to prevent tight loop
-                try? await Task.sleep(for: .milliseconds(100))
+                guard !Task.isCancelled else { return }
+                await self.process(purchased: self.inAppLibrary.status)
             }
         }
     }
@@ -112,19 +111,16 @@ extension SubscriptionViewModel {
 }
 
 private extension SubscriptionViewModel {
-    func process(purchased: InAppStatus) {
+    func process(purchased: InAppStatus) async {
         switch purchased {
         case let .purchased(identifier):
             if let transaction = status.product(using: identifier) {
-                Task {
-                    analytics?.track(
-                        .purchaseCompleted(productId: identifier,
-                                           revenue: transaction.price)
-                    )
-
-                    await change(expirationDate: transaction.expirationDate)
-                    isValidSubscription = storage?.settings?.subscription.isValidSubscription ?? false
-                }
+                analytics?.track(
+                    .purchaseCompleted(productId: identifier,
+                                       revenue: transaction.price)
+                )
+                await change(expirationDate: transaction.expirationDate)
+                isValidSubscription = storage?.settings?.subscription.isValidSubscription ?? false
             }
 
         case .cancelled:

--- a/MacMagazine/Features/SettingsLibrary/Sources/SettingsLibrary/Views/Supplementals/SubscriptionView.swift
+++ b/MacMagazine/Features/SettingsLibrary/Sources/SettingsLibrary/Views/Supplementals/SubscriptionView.swift
@@ -54,6 +54,11 @@ struct SubscriptionView: View {
                 viewModel.isPatrao = value
             }
         }
+        .onChange(of: viewModel.isValidSubscription) { _, value in
+            if value {
+                settingsViewModel.removeAds = settingsViewModel.storage.settings?.subscription.removeAds ?? false
+            }
+        }
     }
 }
 


### PR DESCRIPTION
## Summary
- Replace broken 100ms polling loop in `SubscriptionViewModel.setupListeners()` with proper `withObservationTracking` + `withCheckedContinuation` that suspends until `InAppManager.status` mutates
- Make `process(purchased:)` fully `async` to eliminate fire-and-forget Task race condition where DB save never completed before status reset
- Add defensive `.onChange(of: viewModel.isValidSubscription)` in `SubscriptionView` to ensure `removeAds` environment updates even if `ModelContext.didSave` notification is missed

## Test plan
- [ ] Build succeeds on iPhone 17 Pro simulator
- [ ] All 44 tests pass
- [ ] SwiftLint passes with `--strict`
- [ ] Subscribe via StoreKit sandbox → verify ads disappear immediately without app restart
- [ ] Verify patrão login still works correctly (unchanged path)
- [ ] Verify restore purchase flow still functions

🤖 Generated with [Claude Code](https://claude.com/claude-code)