### PR TITLE
fix(webview): defer WebView insertion on Mac to prevent animation crash

### DIFF
--- a/MacMagazine/Features/MacMagazineUILibrary/Sources/MacMagazineUILibrary/Webview/MMWebView.swift
+++ b/MacMagazine/Features/MacMagazineUILibrary/Sources/MacMagazineUILibrary/Webview/MMWebView.swift
@@ -12,7 +12,6 @@ public struct MMWebView: View {
     @State private var page: WebPage?
     @State private var navigationDecider = MMNavigationDecider()
     @State private var reloadID = UUID()
-    @State private var showDebugAlert = false
 
     private let url: String?
     private let cacheKey: String?
@@ -64,14 +63,6 @@ public struct MMWebView: View {
         }
         .onChange(of: colorScheme) {
             page?.reload()
-        }
-        .onAppear {
-            showDebugAlert = true
-        }
-        .alert("Debug: removeAds", isPresented: $showDebugAlert) {
-            Button("OK", role: .cancel) {}
-        } message: {
-            Text("removeAds = \(removeAds)")
         }
     }
 }

--- a/MacMagazine/Features/MacMagazineUILibrary/Sources/MacMagazineUILibrary/Webview/MMWebView.swift
+++ b/MacMagazine/Features/MacMagazineUILibrary/Sources/MacMagazineUILibrary/Webview/MMWebView.swift
@@ -12,6 +12,7 @@ public struct MMWebView: View {
     @State private var page: WebPage?
     @State private var navigationDecider = MMNavigationDecider()
     @State private var reloadID = UUID()
+    @State private var showDebugAlert = false
 
     private let url: String?
     private let cacheKey: String?
@@ -63,6 +64,14 @@ public struct MMWebView: View {
         }
         .onChange(of: colorScheme) {
             page?.reload()
+        }
+        .onAppear {
+            showDebugAlert = true
+        }
+        .alert("Debug: removeAds", isPresented: $showDebugAlert) {
+            Button("OK", role: .cancel) {}
+        } message: {
+            Text("removeAds = \(removeAds)")
         }
     }
 }

--- a/MacMagazine/Features/MacMagazineUILibrary/Sources/MacMagazineUILibrary/Webview/ManagedWebView.swift
+++ b/MacMagazine/Features/MacMagazineUILibrary/Sources/MacMagazineUILibrary/Webview/ManagedWebView.swift
@@ -31,6 +31,7 @@ public struct ManagedWebView: View {
 
     @State private var viewStatus = WebViewStatus.idle
     @State private var isActive = true
+    @State private var webViewReadyToRender = !ProcessInfo.processInfo.isiOSAppOnMac
 
     let style: ManagedWebViewStyle
     let pageProvider: @MainActor () async -> WebPage?
@@ -72,6 +73,16 @@ public struct ManagedWebView: View {
                 self.page = activePage
             }
             guard let activePage else { return }
+
+            if !webViewReadyToRender {
+                // On Mac, delay WebView insertion to escape the animation context
+                // that NavigationSplitView applies during detail content transitions.
+                try? await Task.sleep(for: .milliseconds(100))
+                webViewReadyToRender = true
+                // Yield to allow SwiftUI to render the WebView before loading content.
+                try? await Task.sleep(for: .milliseconds(50))
+            }
+
             await performLoad(on: activePage)
         }
         .onChange(of: scenePhase) { _, newPhase in
@@ -93,12 +104,11 @@ public struct ManagedWebView: View {
 private extension ManagedWebView {
     @ViewBuilder
     var webview: some View {
-        if let page, isActive {
+        if let page, isActive, webViewReadyToRender {
             Color.clear
                 .allowsHitTesting(false)
                 .safeAreaInset(edge: .trailing, spacing: shouldUseSidebar ? nil : 0) {
                     WebView(page)
-                        .transaction { $0.disablesAnimations = true }
                         .webViewBackForwardNavigationGestures(
                             style.backForwardGesturesDisabled ? .disabled : .enabled
                         )

--- a/MacMagazine/Features/MacMagazineUILibrary/Sources/MacMagazineUILibrary/Webview/ManagedWebView.swift
+++ b/MacMagazine/Features/MacMagazineUILibrary/Sources/MacMagazineUILibrary/Webview/ManagedWebView.swift
@@ -98,13 +98,13 @@ private extension ManagedWebView {
                 .allowsHitTesting(false)
                 .safeAreaInset(edge: .trailing, spacing: shouldUseSidebar ? nil : 0) {
                     WebView(page)
+                        .transaction { $0.disablesAnimations = true }
                         .webViewBackForwardNavigationGestures(
                             style.backForwardGesturesDisabled ? .disabled : .enabled
                         )
                         .scrollBounceBehavior(.basedOnSize, axes: .horizontal)
                         .ignoresSafeArea(.container, edges: style.ignoredSafeAreaEdges)
                         .opacity(viewStatus == .done ? 1 : 0)
-                        .transition(.opacity)
                 }
         }
     }


### PR DESCRIPTION
## Summary
- Defer `WebView(page)` insertion by 100ms on Mac (Designed for iPad) to escape NavigationSplitView's implicit animation context that crashes WebKit's `makeUIView`
- Uses `ProcessInfo.processInfo.isiOSAppOnMac` — iOS/iPadOS completely unaffected (zero delay)
- Removes redundant `.transition(.opacity)` from ManagedWebView

Closes #276

## Test plan
- [ ] Mac → sidebar → Instagram → no crash
- [ ] iPhone → Social tab → segment switch → works normally, no delay
- [ ] Other webview pages (Live, article detail) still work on Mac

🤖 Generated with [Claude Code](https://claude.com/claude-code)