### PR TITLE
fix(#278): restore swipe-to-exit gesture in posts without breaking image galleries

### DIFF
--- a/MacMagazine/Features/MacMagazineUILibrary/Sources/MacMagazineUILibrary/Webview/GalleryStateMessageHandler.swift
+++ b/MacMagazine/Features/MacMagazineUILibrary/Sources/MacMagazineUILibrary/Webview/GalleryStateMessageHandler.swift
@@ -1,0 +1,18 @@
+import WebKit
+
+/// Receives gallery open/close notifications posted by
+/// `MMWebViewUserScripts.galleryStateObserver`.
+@MainActor
+final class GalleryStateMessageHandler: NSObject, WKScriptMessageHandler {
+    static let handlerName = "mmGalleryState"
+
+    var onGalleryStateChange: ((Bool) -> Void)?
+
+    func userContentController(
+        _ userContentController: WKUserContentController,
+        didReceive message: WKScriptMessage
+    ) {
+        guard let isOpen = message.body as? Bool else { return }
+        onGalleryStateChange?(isOpen)
+    }
+}

--- a/MacMagazine/Features/MacMagazineUILibrary/Sources/MacMagazineUILibrary/Webview/InteractivePopGesture.swift
+++ b/MacMagazine/Features/MacMagazineUILibrary/Sources/MacMagazineUILibrary/Webview/InteractivePopGesture.swift
@@ -39,6 +39,14 @@ private final class BridgeViewController: UIViewController, UIGestureRecognizerD
 
     override func viewWillDisappear(_ animated: Bool) {
         super.viewWillDisappear(animated)
+        restoreDelegate()
+    }
+
+    isolated deinit {
+        restoreDelegate()
+    }
+
+    private func restoreDelegate() {
         if let popGesture, popGesture.delegate === self {
             popGesture.delegate = originalDelegate
         }

--- a/MacMagazine/Features/MacMagazineUILibrary/Sources/MacMagazineUILibrary/Webview/InteractivePopGesture.swift
+++ b/MacMagazine/Features/MacMagazineUILibrary/Sources/MacMagazineUILibrary/Webview/InteractivePopGesture.swift
@@ -1,0 +1,55 @@
+import SwiftUI
+import UIKit
+
+public extension View {
+    /// Restores the interactive pop gesture (swipe from the leading edge to go back)
+    /// even when the system back button is hidden, and disables it on demand —
+    /// e.g. while an in-page image gallery is open and owns horizontal swipes.
+    func interactivePopGesture(enabled: Bool) -> some View {
+        background(InteractivePopGestureBridge(enabled: enabled))
+    }
+}
+
+private struct InteractivePopGestureBridge: UIViewControllerRepresentable {
+    let enabled: Bool
+
+    func makeUIViewController(context: Context) -> BridgeViewController {
+        BridgeViewController()
+    }
+
+    func updateUIViewController(_ controller: BridgeViewController, context: Context) {
+        controller.gestureEnabled = enabled
+    }
+}
+
+private final class BridgeViewController: UIViewController, UIGestureRecognizerDelegate {
+    var gestureEnabled = true
+
+    private weak var popGesture: UIGestureRecognizer?
+    private weak var originalDelegate: UIGestureRecognizerDelegate?
+
+    override func viewDidAppear(_ animated: Bool) {
+        super.viewDidAppear(animated)
+        guard popGesture == nil,
+              let gesture = navigationController?.interactivePopGestureRecognizer else { return }
+        popGesture = gesture
+        originalDelegate = gesture.delegate
+        gesture.delegate = self
+    }
+
+    override func viewWillDisappear(_ animated: Bool) {
+        super.viewWillDisappear(animated)
+        if let popGesture, popGesture.delegate === self {
+            popGesture.delegate = originalDelegate
+        }
+        popGesture = nil
+        originalDelegate = nil
+    }
+
+    func gestureRecognizerShouldBegin(_ gestureRecognizer: UIGestureRecognizer) -> Bool {
+        guard let navigationController else { return false }
+        return gestureEnabled
+            && navigationController.viewControllers.count > 1
+            && navigationController.transitionCoordinator == nil
+    }
+}

--- a/MacMagazine/Features/MacMagazineUILibrary/Sources/MacMagazineUILibrary/Webview/MMWebView.swift
+++ b/MacMagazine/Features/MacMagazineUILibrary/Sources/MacMagazineUILibrary/Webview/MMWebView.swift
@@ -11,6 +11,8 @@ public struct MMWebView: View {
     @State private var internalLinkURL: URL?
     @State private var page: WebPage?
     @State private var navigationDecider = MMNavigationDecider()
+    @State private var galleryStateHandler = GalleryStateMessageHandler()
+    @State private var isGalleryOpen = false
     @State private var reloadID = UUID()
 
     private let url: String?
@@ -41,6 +43,7 @@ public struct MMWebView: View {
             page: $page,
             reloadTrigger: reloadID
         )
+        .interactivePopGesture(enabled: !isGalleryOpen)
         .navigationDestination(item: $internalLinkURL) { url in
             MMWebView(url: url.absoluteString, dismissAction: dismissAction)
                 .toolbar {
@@ -102,6 +105,7 @@ private extension MMWebView {
 
         navigationDecider.onOpenComments = { [self] slug in commentsURL = slug }
         navigationDecider.onOpenInternalLink = { [self] url in internalLinkURL = url }
+        galleryStateHandler.onGalleryStateChange = { [self] isOpen in isGalleryOpen = isOpen }
 
         let configuration = makeConfiguration()
         let page: WebPage
@@ -138,6 +142,8 @@ private extension MMWebView {
         contentController.addUserScript(MMWebViewUserScripts.disableGallery)
         contentController.addUserScript(MMWebViewUserScripts.disableNewGallery)
         contentController.addUserScript(MMWebViewUserScripts.removeBackToBlog)
+        contentController.addUserScript(MMWebViewUserScripts.galleryStateObserver)
+        contentController.add(galleryStateHandler, name: GalleryStateMessageHandler.handlerName)
 
         return configuration
     }

--- a/MacMagazine/Features/MacMagazineUILibrary/Sources/MacMagazineUILibrary/Webview/MMWebView.swift
+++ b/MacMagazine/Features/MacMagazineUILibrary/Sources/MacMagazineUILibrary/Webview/MMWebView.swift
@@ -65,12 +65,14 @@ public struct MMWebView: View {
             }
         }
         .onChange(of: colorScheme) {
+            isGalleryOpen = false
             page?.reload()
         }
         .onChange(of: removeAds) {
             if let cacheKey {
                 WebPageCache.shared.removePage(for: cacheKey)
             }
+            isGalleryOpen = false
             page = nil
             reloadID = UUID()
         }
@@ -114,8 +116,11 @@ private extension MMWebView {
             page = WebPageCache.shared.page(
                 for: cacheKey,
                 configurationProvider: { configuration },
-                navigationDecider: navigationDecider
+                navigationDecider: navigationDecider,
+                galleryStateHandler: galleryStateHandler
             )
+            WebPageCache.shared.galleryHandler(for: cacheKey)?
+                .onGalleryStateChange = { [self] isOpen in isGalleryOpen = isOpen }
         } else {
             page = WebPage(
                 configuration: configuration,

--- a/MacMagazine/Features/MacMagazineUILibrary/Sources/MacMagazineUILibrary/Webview/MMWebViewUserScripts.swift
+++ b/MacMagazine/Features/MacMagazineUILibrary/Sources/MacMagazineUILibrary/Webview/MMWebViewUserScripts.swift
@@ -50,6 +50,36 @@ public enum MMWebViewUserScripts {
     }
 
     @MainActor
+    static var galleryStateObserver: WKUserScript {
+        WKUserScript(
+            source: """
+            (function() {
+                if (window.__mmGalleryObserver) { return; }
+                var selectors = '.pswp--open, .fancybox-container, #fancybox-overlay, .mfp-wrap';
+                var lastState = false;
+                function check() {
+                    var open = !!document.querySelector(selectors);
+                    if (open !== lastState) {
+                        lastState = open;
+                        window.webkit.messageHandlers.mmGalleryState.postMessage(open);
+                    }
+                }
+                var observer = new MutationObserver(check);
+                observer.observe(document.documentElement, {
+                    attributes: true,
+                    childList: true,
+                    subtree: true,
+                    attributeFilter: ['class', 'style']
+                });
+                window.__mmGalleryObserver = observer;
+            })();
+            """,
+            injectionTime: .atDocumentEnd,
+            forMainFrameOnly: true
+        )
+    }
+
+    @MainActor
     public static var hideSiteHeader: WKUserScript {
         WKUserScript(
             source: """

--- a/MacMagazine/Features/MacMagazineUILibrary/Sources/MacMagazineUILibrary/Webview/MMWebViewUserScripts.swift
+++ b/MacMagazine/Features/MacMagazineUILibrary/Sources/MacMagazineUILibrary/Webview/MMWebViewUserScripts.swift
@@ -56,7 +56,7 @@ public enum MMWebViewUserScripts {
             (function() {
                 if (window.__mmGalleryObserver) { return; }
                 var selectors = '.pswp--open, .fancybox-container, #fancybox-overlay, .mfp-wrap';
-                var lastState = false;
+                var lastState = null;
                 function check() {
                     var open = !!document.querySelector(selectors);
                     if (open !== lastState) {
@@ -72,6 +72,7 @@ public enum MMWebViewUserScripts {
                     attributeFilter: ['class', 'style']
                 });
                 window.__mmGalleryObserver = observer;
+                check();
             })();
             """,
             injectionTime: .atDocumentEnd,

--- a/MacMagazine/Features/MacMagazineUILibrary/Sources/MacMagazineUILibrary/Webview/WebPageCache.swift
+++ b/MacMagazine/Features/MacMagazineUILibrary/Sources/MacMagazineUILibrary/Webview/WebPageCache.swift
@@ -5,6 +5,7 @@ final class WebPageCache {
     static let shared = WebPageCache()
 
     private var cache: [String: WebPage] = [:]
+    private var galleryHandlers: [String: GalleryStateMessageHandler] = [:]
 
     private init() {}
 
@@ -20,7 +21,8 @@ final class WebPageCache {
     func page(
         for key: String,
         configurationProvider: () -> WebPage.Configuration,
-        navigationDecider: some WebPage.NavigationDeciding
+        navigationDecider: some WebPage.NavigationDeciding,
+        galleryStateHandler: GalleryStateMessageHandler
     ) -> WebPage {
         if let existing = cache[key] {
             return existing
@@ -30,7 +32,12 @@ final class WebPageCache {
             navigationDecider: navigationDecider
         )
         cache[key] = page
+        galleryHandlers[key] = galleryStateHandler
         return page
+    }
+
+    func galleryHandler(for key: String) -> GalleryStateMessageHandler? {
+        galleryHandlers[key]
     }
 
     func hasPage(for key: String) -> Bool {
@@ -39,5 +46,6 @@ final class WebPageCache {
 
     func removePage(for key: String) {
         cache.removeValue(forKey: key)
+        galleryHandlers.removeValue(forKey: key)
     }
 }


### PR DESCRIPTION
## Problema (#278)

O gesto de deslizar para sair de posts foi perdido na v5 e, ao mesmo tempo, continuava ativo em posts abertos pela busca — conflitando com as galerias de imagens.

**Causa raiz (dois lados):**
- `NewsView` usa `.navigationBarBackButtonHidden(true)` para o botão de voltar customizado — isso desativa silenciosamente o gesto interativo de pop do SwiftUI. Por isso o gesto sumiu nos posts.
- `SearchView` nunca escondeu o back button — o gesto continuou vivo lá e conflitava com as galerias, exatamente como relatado.
- Os scripts `disableGallery`/`disableNewGallery` só anulam o `href` dos links, mas a galeria do Powerkit (PhotoSwipe) registra handlers de clique via JS — então as galerias continuam abrindo no app.

## Solução

- **`InteractivePopGesture.swift`** (novo): bridge UIKit que restaura o `interactivePopGestureRecognizer` mesmo com o back button escondido. Protegido: só dispara com a stack de navegação acima da raiz e sem transição em andamento; restaura o delegate original ao desaparecer.
- **`MMWebViewUserScripts.galleryStateObserver`** (novo script): MutationObserver que detecta lightbox aberto (`.pswp--open` PhotoSwipe/Powerkit, fancybox, magnific) e notifica o lado nativo.
- **`GalleryStateMessageHandler.swift`** (novo): recebe as mensagens de estado da galeria.
- **`MMWebView`**: galeria aberta ⇒ gesto suspenso; galeria fechada ⇒ deslizar para sair funciona.

Comportamento unificado em: detalhe de notícias, resultados de busca e links internos aninhados. WebViews na raiz (Live, Instagram) não são afetadas pelo guard de profundidade da stack.

## Testes

- Build completo: ✅ (iPhone 17 Pro simulator)
- Testes do MacMagazineUILibrary: ✅ 58/58
- SwiftLint strict nos arquivos alterados: ✅ 0 violações
- Testado em iPhone 12 físico (iOS 26.5): deslizar para sair funciona; dentro da galeria, swipe navega imagens sem sair do post; comportamento idêntico via busca.

Fixes #278

🤖 Generated with [Claude Code](https://claude.com/claude-code)