### PR TITLE
fix(#312): deep linking for widgets, custom URLs, and Universal Links

### DIFF
--- a/MacMagazine/MacMagazine/MainApp/MainViewModel.swift
+++ b/MacMagazine/MacMagazine/MainApp/MainViewModel.swift
@@ -88,10 +88,10 @@ class MainViewModel {
 // MARK: - Deep Link
 
 extension MainViewModel {
-    func openDeepLink(_ url: URL) {
+    func openDeepLink(_ url: URL, source: String = "widget") {
         deepLinkPostURL = url.absoluteString
         analytics.track(.buttonTap(
-            buttonId: AnalyticsConstants.ButtonID.deepLinkOpened("widget").id,
+            buttonId: AnalyticsConstants.ButtonID.deepLinkOpened(source).id,
             screen: AnalyticsConstants.Screen.deepLinkDetail.name
         ))
     }

--- a/MacMagazine/MacMagazine/MainApp/MainViewModel.swift
+++ b/MacMagazine/MacMagazine/MainApp/MainViewModel.swift
@@ -85,6 +85,18 @@ class MainViewModel {
     }
 }
 
+// MARK: - Deep Link
+
+extension MainViewModel {
+    func openDeepLink(_ url: URL) {
+        deepLinkPostURL = url.absoluteString
+        analytics.track(.buttonTap(
+            buttonId: AnalyticsConstants.ButtonID.deepLinkOpened("widget").id,
+            screen: AnalyticsConstants.Screen.deepLinkDetail.name
+        ))
+    }
+}
+
 // MARK: - Onboarding
 
 extension MainViewModel {

--- a/MacMagazine/MacMagazine/MainApp/SceneDelegate.swift
+++ b/MacMagazine/MacMagazine/MainApp/SceneDelegate.swift
@@ -27,15 +27,27 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
             ShortcutManager.shared.pendingShortcut = shortcutItem
         }
         openDeepLink(from: connectionOptions.urlContexts)
+        openUniversalLink(from: connectionOptions.userActivities)
     }
 
     func scene(_ scene: UIScene, openURLContexts URLContexts: Set<UIOpenURLContext>) {
         openDeepLink(from: URLContexts)
     }
 
+    func scene(_ scene: UIScene, continue userActivity: NSUserActivity) {
+        openUniversalLink(from: [userActivity])
+    }
+
     private func openDeepLink(from contexts: Set<UIOpenURLContext>) {
         guard let url = contexts.first?.url else { return }
         viewModel?.openDeepLink(url)
+    }
+
+    private func openUniversalLink(from activities: Set<NSUserActivity>) {
+        guard let url = activities
+            .first(where: { $0.activityType == NSUserActivityTypeBrowsingWeb })?
+            .webpageURL else { return }
+        viewModel?.openDeepLink(url, source: "universal_link")
     }
 
     func windowScene(_ windowScene: UIWindowScene,

--- a/MacMagazine/MacMagazine/MainApp/SceneDelegate.swift
+++ b/MacMagazine/MacMagazine/MainApp/SceneDelegate.swift
@@ -6,6 +6,7 @@ import UIKit
 class SceneDelegate: UIResponder, UIWindowSceneDelegate {
     var window: UIWindow?
     let pushNotification = PushNotification()
+    private var viewModel: MainViewModel?
 
     func scene(_ scene: UIScene,
                willConnectTo session: UISceneSession,
@@ -16,6 +17,7 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
         (UIApplication.shared.delegate as? AppDelegate)?.pushNotification = pushNotification
 
         let viewModel = MainViewModel(pushNotification: pushNotification)
+        self.viewModel = viewModel
 
         window = UIWindow(windowScene: windowScene)
         window?.rootViewController = UIHostingController(rootView: SceneView(viewModel: viewModel))
@@ -24,6 +26,16 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
         if let shortcutItem = connectionOptions.shortcutItem {
             ShortcutManager.shared.pendingShortcut = shortcutItem
         }
+        openDeepLink(from: connectionOptions.urlContexts)
+    }
+
+    func scene(_ scene: UIScene, openURLContexts URLContexts: Set<UIOpenURLContext>) {
+        openDeepLink(from: URLContexts)
+    }
+
+    private func openDeepLink(from contexts: Set<UIOpenURLContext>) {
+        guard let url = contexts.first?.url else { return }
+        viewModel?.openDeepLink(url)
     }
 
     func windowScene(_ windowScene: UIWindowScene,

--- a/MacMagazine/MacMagazine/Resources/MacMagazine.entitlements
+++ b/MacMagazine/MacMagazine/Resources/MacMagazine.entitlements
@@ -6,6 +6,11 @@
 	<string>Development</string>
 	<key>com.apple.developer.aps-environment</key>
 	<string>Development</string>
+	<key>com.apple.developer.associated-domains</key>
+	<array>
+		<string>applinks:macmagazine.com.br</string>
+		<string>applinks:www.macmagazine.com.br</string>
+	</array>
 	<key>com.apple.developer.icloud-container-identifiers</key>
 	<array>
 		<string>iCloud.com.brit.macmagazine.cloudkit</string>

--- a/MacMagazine/MacMagazine/Resources/MacMagazineRelease.entitlements
+++ b/MacMagazine/MacMagazine/Resources/MacMagazineRelease.entitlements
@@ -6,6 +6,11 @@
 	<string>Production</string>
 	<key>com.apple.developer.aps-environment</key>
 	<string>Production</string>
+	<key>com.apple.developer.associated-domains</key>
+	<array>
+		<string>applinks:macmagazine.com.br</string>
+		<string>applinks:www.macmagazine.com.br</string>
+	</array>
 	<key>com.apple.developer.icloud-container-identifiers</key>
 	<array>
 		<string>iCloud.com.brit.macmagazine.cloudkit</string>

--- a/Support/AssociatedDomains/README.md
+++ b/Support/AssociatedDomains/README.md
@@ -1,0 +1,39 @@
+# Associated Domains (Universal Links)
+
+Reference copy of the `apple-app-site-association` (AASA) file that must be hosted for
+Universal Links to open `macmagazine.com.br` post URLs in the app instead of Safari.
+
+## Hosting requirements
+
+Serve the `apple-app-site-association` file (this exact content, **no `.json` extension**) at:
+
+```
+https://macmagazine.com.br/.well-known/apple-app-site-association
+https://www.macmagazine.com.br/.well-known/apple-app-site-association
+```
+
+- HTTPS only, valid certificate.
+- `Content-Type: application/json`.
+- **No redirects** — must return `200` directly.
+- Both apex and `www` must serve it (the app declares `applinks:` for both).
+
+## Scope
+
+`components` allows only `/post/*`, so only article URLs open the app; every other path
+(homepage, categories, `/wp-admin`, etc.) stays in the browser.
+
+## App side (already in the repo)
+
+- `com.apple.developer.associated-domains` in `MacMagazine/Resources/MacMagazine.entitlements`
+  and `MacMagazineRelease.entitlements`.
+- `SceneDelegate` handles the browsing-web `NSUserActivity` (cold + warm launch).
+
+Enable the **Associated Domains** capability on the `com.brit.macmagazine` App ID in the
+Developer portal and regenerate provisioning profiles before device/TestFlight builds.
+
+## Verify after hosting
+
+```bash
+curl -sI https://macmagazine.com.br/.well-known/apple-app-site-association
+xcrun simctl openurl booted https://macmagazine.com.br/post/2025/12/03/<slug>/
+```

--- a/Support/AssociatedDomains/apple-app-site-association
+++ b/Support/AssociatedDomains/apple-app-site-association
@@ -1,0 +1,15 @@
+{
+  "applinks": {
+    "details": [
+      {
+        "appIDs": ["A5VW9QUF9L.com.brit.macmagazine"],
+        "components": [
+          {
+            "/": "/post/*",
+            "comment": "Only post URLs open the app; everything else stays in the browser."
+          }
+        ]
+      }
+    ]
+  }
+}


### PR DESCRIPTION
Fixes deep linking end-to-end for MacMagazine post URLs. Covers three entry points under #312: **widget taps**, **custom URLs**, and **Universal Links** (web links opening the app instead of Safari).

## Problem

1. Tapping any widget opened the app but **nothing happened**, on every widget size.
2. Tapping a `macmagazine.com.br` post link in Safari/Messages/Mail opened the **browser**, never the app.

## Root cause

The app runs on the **UIKit scene lifecycle** (`AppDelegate` installs a `SceneDelegate` that hosts `SceneView` in a `UIHostingController`; the `@main` `WindowGroup` is `EmptyView()`). Under a `UISceneDelegate`, SwiftUI's `.onOpenURL` **never fires**, and `SceneDelegate` handled only shortcut items — so widget URLs were dropped. Separately, the app declared **no Associated Domains** and handled no browsing-web `NSUserActivity`, so it could not claim its own web URLs.

## Fix

- **Widget / custom URL:** `SceneDelegate` now handles `scene(_:openURLContexts:)` (warm) and `connectionOptions.urlContexts` (cold).
- **Universal Links:** `SceneDelegate` handles `scene(_:continue:)` (warm) and `connectionOptions.userActivities` (cold), filtering for `NSUserActivityTypeBrowsingWeb`.
- All sources funnel into `MainViewModel.openDeepLink(_:source:)`, which sets `deepLinkPostURL` and tracks analytics per source (`widget` vs `universal_link`). Reuses the existing `DeepLinkNewsDetailView` → `MMWebView` path — no new routing.
- Added `com.apple.developer.associated-domains` (apex + `www`) to debug and release entitlements.
- Added a ready-to-host reference AASA file under `Support/AssociatedDomains/` (Team ID `A5VW9QUF9L`), scoped to `/post/*` so only article URLs open the app.

## Verification

- ✅ Build succeeded (iPhone 17 simulator — "iPhone 17 Pro" is not installed on this machine).
- ✅ SwiftLint `--strict` on all changed Swift files — 0 violations.
- ✅ AASA JSON validated.
- ⚠️ **Test suite not run (UNVERIFIED):** changed types live in the main app target, which has no test coverage; no new test target created (per decision to ship with manual verification).
- 📱 **Manual check needed:** tap each widget size (cold + warm launch); once the AASA is live, tap a `/post/*` link and confirm it opens the article in-app.

## Required outside this repo (server / portal)

1. Host `Support/AssociatedDomains/apple-app-site-association` at `https://macmagazine.com.br/.well-known/apple-app-site-association` (and `www`) — HTTPS, `application/json`, no redirect, no extension. See the README in that folder.
2. Enable **Associated Domains** on the `com.brit.macmagazine` App ID and regenerate provisioning profiles (device/TestFlight signing; simulator doesn't enforce it).

## Notes / deviations

- No `develop` branch exists — branch is based on `release/v5`; PR targets `release/v5`.
- Left as-is by request: on medium/large widgets, `WidgetView` stamps a container-wide `.widgetURL(content.first?.url)` under `.accessibilityElement(children: .combine)`, which limits **VoiceOver** users to only the first post.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
