### PR TITLE
fix(#315): inject AnalyticsManager into full-player sheets (Mac crash)

### DIFF
--- a/MacMagazine/Features/PodcastLibrary/Sources/Podcast/Modifiers/PodcastMiniPlayerModifier.swift
+++ b/MacMagazine/Features/PodcastLibrary/Sources/Podcast/Modifiers/PodcastMiniPlayerModifier.swift
@@ -1,3 +1,4 @@
+import AnalyticsLibrary
 import FeedLibrary
 import MacMagazineLibrary
 import SwiftUI
@@ -13,6 +14,7 @@ private struct PodcastMiniPlayerModifier: ViewModifier {
     @Environment(PodcastPlayerManager.self) private var manager
     @Environment(\.shouldUseSidebar) private var shouldUseSidebar
     @Environment(\.colorScheme) private var colorScheme
+    @EnvironmentObject private var analytics: AnalyticsManager
     @Namespace private var animation
 
     public init() {}
@@ -32,7 +34,7 @@ private struct PodcastMiniPlayerModifier: ViewModifier {
                         .padding(.horizontal, 20)
                         .glassEffect(.regular)
                     }
-                    .fullPlayerSheet(manager: manager)
+                    .fullPlayerSheet(manager: manager, analytics: analytics)
             } else {
                 content
                     .tabBarMinimizeBehavior(.onScrollDown)
@@ -45,17 +47,17 @@ private struct PodcastMiniPlayerModifier: ViewModifier {
                         .matchedTransitionSource(id: "MINIPLAYER", in: animation)
                         .padding(.horizontal, 8)
                     }
-                    .fullPlayerSheet(manager: manager)
+                    .fullPlayerSheet(manager: manager, analytics: analytics)
             }
         } else {
             content
-                .fullPlayerSheet(manager: manager)
+                .fullPlayerSheet(manager: manager, analytics: analytics)
         }
     }
 }
 
 private extension View {
-    func fullPlayerSheet(manager: PodcastPlayerManager) -> some View {
+    func fullPlayerSheet(manager: PodcastPlayerManager, analytics: AnalyticsManager) -> some View {
         self.sheet(
             isPresented: Binding(
                 get: { manager.isFullscreen },
@@ -67,6 +69,7 @@ private extension View {
                 backgroundGradientStyle: .fourTone
             )
             .presentationDragIndicator(.visible)
+            .environmentObject(analytics)
         }
     }
 }

--- a/MacMagazine/Features/PodcastLibrary/Sources/Podcast/Views/Player/FullPlayerView.swift
+++ b/MacMagazine/Features/PodcastLibrary/Sources/Podcast/Views/Player/FullPlayerView.swift
@@ -78,6 +78,7 @@ struct FullPlayerView: View {
                     isShowingChapterDialog: $isShowingChapterDialog
                 )
                 .presentationDragIndicator(.visible)
+                .environmentObject(analytics)
             }
     }
 


### PR DESCRIPTION
## Problem

The podcast **full player crashed on Mac only** ("My Mac — Designed for iPad") when opened by tapping the mini player.

## Root cause

`FullPlayerView` and `ChaptersView` each read analytics via `@EnvironmentObject var analytics: AnalyticsManager`. Both are presented through `.sheet`. On the iOS-app-on-Mac runtime the sheet is hosted in a separate presentation context that does **not** inherit the root `.environmentObject(viewModel.analytics)`, so the first access traps:

```
Fatal error: No ObservableObject of type AnalyticsManager found.
7  FullPlayerView.actions.getter
21 FullPlayerView.player.getter
22 FullPlayerView.body.getter
```

iPhone/iPad inherit the environment object across the sheet boundary, so the crash was Mac-only.

## Fix

Re-inject `analytics` into the presented sheets, mirroring the existing `DeepLinkNewsDetailView` pattern (which already re-injects `.environmentObject(viewModel.analytics)` into its sheet):

- `PodcastMiniPlayerModifier` reads `@EnvironmentObject analytics` (present in the main hierarchy) and forwards it into the `FullPlayerView` sheet.
- `FullPlayerView` forwards it into the nested `ChaptersView` sheet (same latent crash when opening the chapter list).

The speed popover captures `analytics` directly in its closures rather than doing its own environment lookup, so it needs no change.

## Verification

- ✅ Build succeeded (iPhone 17 simulator; the fix is platform-agnostic Swift).
- ✅ SwiftLint `--strict` on both changed files — 0 violations.
- ⚠️ No unit test: this is SwiftUI-runtime environment propagation across a sheet boundary, not unit-testable (PodcastLibrary's test target can't exercise it).
- 📱 **Needs on-device Mac re-run** to confirm the crash is gone (repro is: mini player → tap to open full player; then open the chapter list).

## Note / potential follow-up (not fixed)

`SystemVolumeView` wraps `MPVolumeView`, which may misbehave on the iOS-app-on-Mac runtime. Because the analytics crash fired first, that path was never reached, so it's unverified. If the volume row misbehaves once the full player opens on Mac, that's a clean separate ticket.

## Notes

- No `develop` branch exists — branch is based on `release/v5`; PR targets `release/v5`.
- No linked issue number (per request), so the commit/PR use a plain `fix(podcast)` scope; CI's title check may expect `fix(#NNN)` — rename if it enforces that.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
