### PR TITLE
feat(settings): restore news filter ordering in customization (#311)

### DIFF
--- a/MacMagazine/Features/SettingsLibrary/Sources/SettingsLibrary/Views/SettingsView.swift
+++ b/MacMagazine/Features/SettingsLibrary/Sources/SettingsLibrary/Views/SettingsView.swift
@@ -92,6 +92,7 @@ private extension SettingsView {
                 AppearanceView()
                 IconsView()
                 CustomTabView()
+                CustomNewsView()
                 CustomSocialView()
             }
             .navigationTitle("Aparência")

--- a/MacMagazine/Features/SettingsLibrary/Sources/SettingsLibrary/Views/Supplementals/CustomNewsView.swift
+++ b/MacMagazine/Features/SettingsLibrary/Sources/SettingsLibrary/Views/Supplementals/CustomNewsView.swift
@@ -1,0 +1,54 @@
+import AnalyticsLibrary
+import MacMagazineLibrary
+import SwiftUI
+
+struct CustomNewsView: View {
+    @EnvironmentObject private var analytics: AnalyticsManager
+    @Environment(\.theme) private var theme: ThemeColor
+    @Environment(SettingsViewModel.self) private var settingsViewModel
+    @State private var viewModel = CustomizationViewModel()
+
+    var body: some View {
+        Section {
+            optionsView
+        } header: {
+            headerView
+        }
+
+        .task {
+            viewModel.storage = settingsViewModel.storage
+            viewModel.get()
+        }
+    }
+}
+
+private extension CustomNewsView {
+    var headerView: some View {
+        VStack(alignment: .leading, spacing: 4) {
+            Text(AppTabs.news.rawValue)
+                .font(.headline)
+            Text("Defina a ordem dos filtros de \(AppTabs.news.rawValue.lowercased()) do aplicativo")
+                .font(.caption)
+        }
+        .foregroundColor(theme.text.terciary.color)
+        .accessibilityElement(children: .ignore)
+        .accessibilityLabel("Customize o app, escolhendo a ordem dos filtros da aba \(AppTabs.news.rawValue.lowercased()).")
+    }
+
+    var optionsView: some View {
+        ForEach($viewModel.news, id: \.self) { $news in
+            Text(news.rawValue)
+        }
+        .onMove(perform: moveItems)
+    }
+}
+
+private extension CustomNewsView {
+    func moveItems(fromIndex: IndexSet, newIndex: Int) {
+        viewModel.news.move(fromOffsets: fromIndex, toOffset: newIndex)
+        Task {
+            await viewModel.change(viewModel.news)
+            analytics.track(.generic(name: AnalyticsConstants.GenericEvent.newsOrder.name, item: viewModel.news))
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Restores the **News filter ordering** option in Settings → Customização do app, letting users drag-reorder the News filter options (Todas, Últimas Notícias, Destaques, Apple TV, Reviews, Rumores, Tutoriais).

The feature was removed in two steps:
- `d85e32cb` "Delete readpost" — disabled it (`CustomNewsView()` → `// CustomNewsView()`)
- `0f22512b` "remove dead code…" — deleted `CustomNewsView.swift`

All supporting infrastructure was still present and wired, so only the view and its call site needed restoring:
- `CustomizationDB.news`, `CustomizationViewModel.news` / `.change(_ news:)`
- `Database.update(news:)`, `AnalyticsConstants.GenericEvent.newsOrder`
- Consumers: `SettingsViewModel.news` → iPad sidebar order + initial selection

## Changes
- **New** `SettingsLibrary/Views/Supplementals/CustomNewsView.swift` — restored, mirroring `CustomSocialView`; copy reworded to reference the news *filters*.
- **Modified** `SettingsLibrary/Views/SettingsView.swift` — `CustomNewsView()` reinserted between `CustomTabView()` and `CustomSocialView()`.

## Quality gates
- ✅ Lint (`--strict`): 0 violations
- ✅ Build: `** BUILD SUCCEEDED **` (iPhone 17 Pro Max, OS 26.5 — iPhone 17 Pro runtime not installed locally)
- ✅ Tests: `** TEST SUCCEEDED **` — 44 tests, 5 suites

Relates to #311

🤖 Generated with [Claude Code](https://claude.com/claude-code)