### PR TITLE
fix(#274): make full 44pt toolbar button circle tappable

### DIFF
--- a/MacMagazine/Features/MacMagazineUILibrary/Sources/MacMagazineUILibrary/Cards/Extensions/MinimumTouchTarget.swift
+++ b/MacMagazine/Features/MacMagazineUILibrary/Sources/MacMagazineUILibrary/Cards/Extensions/MinimumTouchTarget.swift
@@ -15,9 +15,19 @@ private struct MinimumTouchTarget: ViewModifier {
 
     func body(content: Content) -> some View {
         content
-            .buttonStyle(.plain)
+            .buttonStyle(MinimumTouchTargetButtonStyle())
+            .glassEffect(.regular.tint(selected ? selectedColor.opacity(0.3) : .clear).interactive(), in: .circle)
+    }
+}
+
+/// Expands the tappable area from inside the button so the full 44pt circle
+/// receives taps — a `frame`/`contentShape` applied outside a `Button` only
+/// resizes the visual glass, not the button's hit-test region (FB22155477).
+private struct MinimumTouchTargetButtonStyle: ButtonStyle {
+    func makeBody(configuration: Configuration) -> some View {
+        configuration.label
             .frame(width: 44, height: 44)
             .contentShape(Circle())
-            .glassEffect(.regular.tint(selected ? selectedColor.opacity(0.3) : .clear).interactive(), in: .circle)
+            .opacity(configuration.isPressed ? 0.4 : 1)
     }
 }


### PR DESCRIPTION
## Summary

Fixes #274 — intermittent unresponsive liquid glass toolbar buttons (favorite, share, filter) on the home page and on posts: the button animated the touch but the action (share sheet, filter, favorite) sometimes never fired.

## Root cause

`MinimumTouchTarget.swift` applied `.frame(width: 44, height: 44)` + `.contentShape(Circle())` **outside** the `Button`/`ShareLink`. An ancestor's frame/content shape does not extend a descendant button's hit-test region, so the actual tappable area was only the small SF Symbol icon — while `.glassEffect(…).interactive()` covered the full 44pt circle and animated on every touch inside it.

- Tap on the icon → works (most taps, hence "rare")
- Tap inside the glass circle but off the icon → press animation, **no action**

Only toolbar buttons were affected because `.minimumTouchTarget()` is used exclusively on toolbar items. Matching Apple report: [Button in ToolbarItem is not completely tappable on iOS 26](https://developer.apple.com/forums/thread/815492) (FB22155477).

## Fix

Moved the 44pt frame + circular content shape into a custom `ButtonStyle` — a style's body is the button's label, so the full circle now sits inside the button's hit-test region. Works for both `Button` (favorite/filter) and `ShareLink` (share). Pressed-state opacity preserves the `.plain` style feedback; glass effect unchanged. One file; all 6 call sites inherit the fix.

## Verification

- ✅ Build succeeded (iPhone 17 Pro Max simulator, OS 26.5 — no iPhone 17 Pro simulator installed on this machine)
- ✅ 44 tests in 5 suites passed (`-testPlan MacMagazine`)
- ✅ SwiftLint strict: 0 violations in 245 files
- ⚠️ No unit reproduction test: SwiftUI hit-testing is not unit-testable (testing.md excludes view bodies). Manual check: tap the **edge** of the glass circles on device.

🤖 Generated with [Claude Code](https://claude.com/claude-code)