### PR TITLE
fix(#321): mark push-notification deep-linked posts read once synced

### DIFF
--- a/MacMagazine/MacMagazine/Features/News/DeepLinkNewsDetailView.swift
+++ b/MacMagazine/MacMagazine/Features/News/DeepLinkNewsDetailView.swift
@@ -47,6 +47,11 @@ struct DeepLinkNewsDetailView: View {
                     post?.markAsRead()
                     try? modelContext.save()
                 }
+                .onChange(of: post) { _, newValue in
+                    guard let newValue, !newValue.read else { return }
+                    newValue.markAsRead()
+                    try? modelContext.save()
+                }
         }
     }
 


### PR DESCRIPTION
## Summary
- Push-notification deep links could open a brand-new article before it finished syncing into local `FeedDB` (the sync is triggered separately via `shouldReloadContent`), so `DeepLinkNewsDetailView`'s one-shot `.onAppear` computed `post == nil` and silently skipped `markAsRead()`.
- Widget and Home Screen Shortcut deep links only ever point to already-synced posts, so they were unaffected — this made the bug look push-notification-specific.
- Added `.onChange(of: post)` alongside the existing `.onAppear` so the read state is applied reactively once the live `@Query` resolves a matching `FeedDB` row.

## Test plan
- [x] `xcodebuild build` — succeeded (iPhone 17 Pro simulator unavailable on this machine; built against iPhone 17 Pro Max instead)
- [x] `xcodebuild test -testPlan MacMagazine` — 511 tests across all 10 suites passed
- [x] `swiftlint lint --strict` — 0 violations across 243 files
- [ ] No new automated test added for this specific fix: the bug lives in SwiftUI view state-timing (`.onAppear`/`.onChange`), there's no test target for the main `MacMagazine` app target, and project testing rules explicitly exclude testing view bodies — verified by build/lint/manual read only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)